### PR TITLE
Fixed byte-packing and moved to NumericResizeArray for LStrHandle allocation

### DIFF
--- a/extensions/lvssh2_extensions.h
+++ b/extensions/lvssh2_extensions.h
@@ -3,7 +3,7 @@
 #include "extcode.h"
 #include "libssh2/libssh2.h"
 
-#pragma pack(push, 1)
+#include "lv_prolog.h"
 
 typedef struct {
 	unsigned char* data;
@@ -47,9 +47,11 @@ LVUserEventRef* lvssh2_userauth_keyboard_interactive_response_event = { 0 };
 LIBSSH2_USERAUTH_KBDINT_RESPONSE* lvssh2_userauth_keyboard_interactive_response_return_value = { 0 };
 int lvssh2_userauth_keyboard_interactive_response_return_value_count = 0;
 
-#pragma pack(pop)
-
 lvssh2_userauth_publickey_sign_function_output_args lvssh2_userauth_publickey_sign_return_value = { 0 };
+
+#include "lv_epilog.h"
+
+void data_buffer_to_LStrHandle(const char*, size_t, LStrHandle*);
 
 void lvssh2_trace_handler_function(LIBSSH2_SESSION* session, LVUserEventRef* event, const char* data, size_t length);
 int lvssh2_userauth_publickey_sign_function(LIBSSH2_SESSION* session, unsigned char** signature, size_t* signature_len, const unsigned char* data, size_t data_len, LVUserEventRef* event);


### PR DESCRIPTION
I had a review of your lvssh-extension C/C++ code and noticed that you were always applying the byte-packing compiler directive regardless of the bitness.

Only 32-bit builds need to have this applied, 64-bit builds just use the normal byte-packing. Luckily NI provide two headers `lv_prolog.h` and `lv_epilog.h` which automatically handle this.

I have also modified how you are allocating memory for LabVIEW strings. 

As an LV-String has the form

```c
LStr {
   int32_t cnt;
   uChar * str
}
```
it is also affected by the byte-packing, so allocating the correct number of bytes depends on system bitness. Luckily LV-strings have the same structure as 1-D lv-arrays so we can use `NumericArrayResize` to allocate a `U8` array (i.e `chars`) which will automatically account for any padding between the count and the string-buffer pointer.

Finally - I changed how a `char` data-buffer is wrriten to an `LStrHandle`. By using a memcpy/MoveBlock, we can ensure that we are only copying in the number of bytes specified as the data-buffer length instead of relying on a null-termination character in the data-buffer. 

The code builds successfully but I am not sure which examples or tests are suitable to ensure that these modifications are fully tested. I have not included the modified built-dlls from this code as I imagine that you would want to build these yourself.