### PR TITLE
Improve error messages

### DIFF
--- a/lvssh2-errors.txt
+++ b/lvssh2-errors.txt
@@ -6,156 +6,156 @@
 </nifamily>
 </nicomment>
 <nierror code="5000">
-libssh2: (Hex 0x1388) LIBSSH2_ERROR_SOCKET_NONE
+libssh2: (Hex 0x1388) -1, LIBSSH2_ERROR_SOCKET_NONE
 </nierror>
 <nierror code="5001">
-libssh2: (Hex 0x1389) LIBSSH2_ERROR_BANNER_RECV
+libssh2: (Hex 0x1389) -2, LIBSSH2_ERROR_BANNER_RECV
 </nierror>
 <nierror code="5002">
-libssh2: (Hex 0x138A) LIBSSH2_ERROR_BANNER_SEND
+libssh2: (Hex 0x138A) -3, LIBSSH2_ERROR_BANNER_SEND
 </nierror>
 <nierror code="5003">
-libssh2: (Hex 0x138B) LIBSSH2_ERROR_INVALID_MAC
+libssh2: (Hex 0x138B) -4, LIBSSH2_ERROR_INVALID_MAC
 </nierror>
 <nierror code="5004">
-libssh2: (Hex 0x138C) LIBSSH2_ERROR_KEX_FAILURE
+libssh2: (Hex 0x138C) -5, LIBSSH2_ERROR_KEX_FAILURE
 </nierror>
 <nierror code="5005">
-libssh2: (Hex 0x138D) LIBSSH2_ERROR_ALLOC
+libssh2: (Hex 0x138D) -6, LIBSSH2_ERROR_ALLOC
 </nierror>
 <nierror code="5006">
-libssh2: (Hex 0x138E) LIBSSH2_ERROR_SOCKET_SEND
+libssh2: (Hex 0x138E) -7, LIBSSH2_ERROR_SOCKET_SEND
 </nierror>
 <nierror code="5007">
-libssh2: (Hex 0x138F) LIBSSH2_ERROR_KEY_EXCHANGE_FAILURE
+libssh2: (Hex 0x138F) -8, LIBSSH2_ERROR_KEY_EXCHANGE_FAILURE
 </nierror>
 <nierror code="5008">
-libssh2: (Hex 0x1390) LIBSSH2_ERROR_TIMEOUT
+libssh2: (Hex 0x1390) -9, LIBSSH2_ERROR_TIMEOUT
 </nierror>
 <nierror code="5009">
-libssh2: (Hex 0x1391) LIBSSH2_ERROR_HOSTKEY_INIT
+libssh2: (Hex 0x1391) -10, LIBSSH2_ERROR_HOSTKEY_INIT
 </nierror>
 <nierror code="5010">
-libssh2: (Hex 0x1392) LIBSSH2_ERROR_HOSTKEY_SIGN
+libssh2: (Hex 0x1392) -11, LIBSSH2_ERROR_HOSTKEY_SIGN
 </nierror>
 <nierror code="5011">
-libssh2: (Hex 0x1393) LIBSSH2_ERROR_DECRYPT
+libssh2: (Hex 0x1393) -12, LIBSSH2_ERROR_DECRYPT
 </nierror>
 <nierror code="5012">
-libssh2: (Hex 0x1394) LIBSSH2_ERROR_SOCKET_DISCONNECT
+libssh2: (Hex 0x1394) -13, LIBSSH2_ERROR_SOCKET_DISCONNECT
 </nierror>
 <nierror code="5013">
-libssh2: (Hex 0x1395) LIBSSH2_ERROR_PROTO
+libssh2: (Hex 0x1395) -14, LIBSSH2_ERROR_PROTO
 </nierror>
 <nierror code="5014">
-libssh2: (Hex 0x1396) LIBSSH2_ERROR_PASSWORD_EXPIRED
+libssh2: (Hex 0x1396) -15, LIBSSH2_ERROR_PASSWORD_EXPIRED
 </nierror>
 <nierror code="5015">
-libssh2: (Hex 0x1397) LIBSSH2_ERROR_FILE
+libssh2: (Hex 0x1397) -16, LIBSSH2_ERROR_FILE
 </nierror>
 <nierror code="5016">
-libssh2: (Hex 0x1398) LIBSSH2_ERROR_METHOD_NONE
+libssh2: (Hex 0x1398) -17, LIBSSH2_ERROR_METHOD_NONE
 </nierror>
 <nierror code="5017">
-libssh2: (Hex 0x1399) LIBSSH2_ERROR_AUTHENTICATION_FAILED
+libssh2: (Hex 0x1399) -18, LIBSSH2_ERROR_AUTHENTICATION_FAILED
 </nierror>
 <nierror code="5018">
-libssh2: (Hex 0x139A) LIBSSH2_ERROR_PUBLICKEY_UNVERIFIED
+libssh2: (Hex 0x139A) -19, LIBSSH2_ERROR_PUBLICKEY_UNVERIFIED
 </nierror>
 <nierror code="5019">
-libssh2: (Hex 0x139B) LIBSSH2_ERROR_CHANNEL_OUTOFORDER
+libssh2: (Hex 0x139B) -20, LIBSSH2_ERROR_CHANNEL_OUTOFORDER
 </nierror>
 <nierror code="5020">
-libssh2: (Hex 0x139C) LIBSSH2_ERROR_CHANNEL_FAILURE
+libssh2: (Hex 0x139C) -21, LIBSSH2_ERROR_CHANNEL_FAILURE
 </nierror>
 <nierror code="5021">
-libssh2: (Hex 0x139D) LIBSSH2_ERROR_CHANNEL_REQUEST_DENIED
+libssh2: (Hex 0x139D) -22, LIBSSH2_ERROR_CHANNEL_REQUEST_DENIED
 </nierror>
 <nierror code="5022">
-libssh2: (Hex 0x139E) LIBSSH2_ERROR_CHANNEL_UNKNOWN
+libssh2: (Hex 0x139E) -23, LIBSSH2_ERROR_CHANNEL_UNKNOWN
 </nierror>
 <nierror code="5023">
-libssh2: (Hex 0x139F) LIBSSH2_ERROR_CHANNEL_WINDOW_EXCEEDED
+libssh2: (Hex 0x139F) -24, LIBSSH2_ERROR_CHANNEL_WINDOW_EXCEEDED
 </nierror>
 <nierror code="5024">
-libssh2: (Hex 0x13A0) LIBSSH2_ERROR_CHANNEL_PACKET_EXCEEDED
+libssh2: (Hex 0x13A0) -25, LIBSSH2_ERROR_CHANNEL_PACKET_EXCEEDED
 </nierror>
 <nierror code="5025">
-libssh2: (Hex 0x13A1) LIBSSH2_ERROR_CHANNEL_CLOSED
+libssh2: (Hex 0x13A1) -26, LIBSSH2_ERROR_CHANNEL_CLOSED
 </nierror>
 <nierror code="5026">
-libssh2: (Hex 0x13A2) LIBSSH2_ERROR_CHANNEL_EOF_SENT
+libssh2: (Hex 0x13A2) -27, LIBSSH2_ERROR_CHANNEL_EOF_SENT
 </nierror>
 <nierror code="5027">
-libssh2: (Hex 0x13A3) LIBSSH2_ERROR_SCP_PROTOCOL
+libssh2: (Hex 0x13A3) -28, LIBSSH2_ERROR_SCP_PROTOCOL
 </nierror>
 <nierror code="5028">
-libssh2: (Hex 0x13A4) LIBSSH2_ERROR_ZLIB
+libssh2: (Hex 0x13A4) -29, LIBSSH2_ERROR_ZLIB
 </nierror>
 <nierror code="5029">
-libssh2: (Hex 0x13A5) LIBSSH2_ERROR_SOCKET_TIMEOUT
+libssh2: (Hex 0x13A5) -30, LIBSSH2_ERROR_SOCKET_TIMEOUT
 </nierror>
 <nierror code="5030">
-libssh2: (Hex 0x13A6) LIBSSH2_ERROR_SFTP_PROTOCOL
+libssh2: (Hex 0x13A6) -31, LIBSSH2_ERROR_SFTP_PROTOCOL
 </nierror>
 <nierror code="5031">
-libssh2: (Hex 0x13A7) LIBSSH2_ERROR_REQUEST_DENIED
+libssh2: (Hex 0x13A7) -32, LIBSSH2_ERROR_REQUEST_DENIED
 </nierror>
 <nierror code="5032">
-libssh2: (Hex 0x13A8) LIBSSH2_ERROR_METHOD_NOT_SUPPORTED
+libssh2: (Hex 0x13A8) -33, LIBSSH2_ERROR_METHOD_NOT_SUPPORTED
 </nierror>
 <nierror code="5033">
-libssh2: (Hex 0x13A9) LIBSSH2_ERROR_INVAL
+libssh2: (Hex 0x13A9) -34, LIBSSH2_ERROR_INVAL
 </nierror>
 <nierror code="5034">
-libssh2: (Hex 0x13AA) LIBSSH2_ERROR_INVALID_POLL_TYPE
+libssh2: (Hex 0x13AA) -35, LIBSSH2_ERROR_INVALID_POLL_TYPE
 </nierror>
 <nierror code="5035">
-libssh2: (Hex 0x13AB) LIBSSH2_ERROR_PUBLICKEY_PROTOCOL
+libssh2: (Hex 0x13AB) -36, LIBSSH2_ERROR_PUBLICKEY_PROTOCOL
 </nierror>
 <nierror code="5036">
-libssh2: (Hex 0x13AC) LIBSSH2_ERROR_EAGAIN
+libssh2: (Hex 0x13AC) -37, LIBSSH2_ERROR_EAGAIN
 </nierror>
 <nierror code="5037">
-libssh2: (Hex 0x13AD) LIBSSH2_ERROR_BUFFER_TOO_SMALL
+libssh2: (Hex 0x13AD) -38, LIBSSH2_ERROR_BUFFER_TOO_SMALL
 </nierror>
 <nierror code="5038">
-libssh2: (Hex 0x13AE) LIBSSH2_ERROR_BAD_USE
+libssh2: (Hex 0x13AE) -39, LIBSSH2_ERROR_BAD_USE
 </nierror>
 <nierror code="5039">
-libssh2: (Hex 0x13AF) LIBSSH2_ERROR_COMPRESS
+libssh2: (Hex 0x13AF) -40, LIBSSH2_ERROR_COMPRESS
 </nierror>
 <nierror code="5040">
-libssh2: (Hex 0x13B0) LIBSSH2_ERROR_OUT_OF_BOUNDARY
+libssh2: (Hex 0x13B0) -41, LIBSSH2_ERROR_OUT_OF_BOUNDARY
 </nierror>
 <nierror code="5041">
-libssh2: (Hex 0x13B1) LIBSSH2_ERROR_AGENT_PROTOCOL
+libssh2: (Hex 0x13B1) -42, LIBSSH2_ERROR_AGENT_PROTOCOL
 </nierror>
 <nierror code="5042">
-libssh2: (Hex 0x13B2) LIBSSH2_ERROR_SOCKET_RECV
+libssh2: (Hex 0x13B2) -43, LIBSSH2_ERROR_SOCKET_RECV
 </nierror>
 <nierror code="5043">
-libssh2: (Hex 0x13B3) LIBSSH2_ERROR_ENCRYPT
+libssh2: (Hex 0x13B3) -44, LIBSSH2_ERROR_ENCRYPT
 </nierror>
 <nierror code="5044">
-libssh2: (Hex 0x13B4) LIBSSH2_ERROR_BAD_SOCKET
+libssh2: (Hex 0x13B4) -45, LIBSSH2_ERROR_BAD_SOCKET
 </nierror>
 <nierror code="5045">
-libssh2: (Hex 0x13B5) LIBSSH2_ERROR_KNOWN_HOSTS
+libssh2: (Hex 0x13B5) -46, LIBSSH2_ERROR_KNOWN_HOSTS
 </nierror>
 <nierror code="5046">
-libssh2: (Hex 0x13B6) LIBSSH2_ERROR_CHANNEL_WINDOW_FULL
+libssh2: (Hex 0x13B6) -47, LIBSSH2_ERROR_CHANNEL_WINDOW_FULL
 </nierror>
 <nierror code="5047">
-libssh2: (Hex 0x13B7) LIBSSH2_ERROR_KEYFILE_AUTH_FAILED
+libssh2: (Hex 0x13B7) -48, LIBSSH2_ERROR_KEYFILE_AUTH_FAILED
 </nierror>
 <nierror code="5048">
-libssh2: (Hex 0x13B8) LIBSSH2_ERROR_RANDGEN
+libssh2: (Hex 0x13B8) -49, LIBSSH2_ERROR_RANDGEN
 </nierror>
 <nierror code="5049">
-libssh2: (Hex 0x13B9) LIBSSH2_ERROR_MISSING_USERAUTH_BANNER
+libssh2: (Hex 0x13B9) -50, LIBSSH2_ERROR_MISSING_USERAUTH_BANNER
 </nierror>
 <nierror code="5050">
-libssh2: (Hex 0x13BA) LIBSSH2_ERROR_ALGO_UNSUPPORTED
+libssh2: (Hex 0x13BA) -51, LIBSSH2_ERROR_ALGO_UNSUPPORTED
 </nierror>
 </nidocument>

--- a/lvssh2-errors.txt
+++ b/lvssh2-errors.txt
@@ -7,155 +7,206 @@
 </nicomment>
 <nierror code="5000">
 libssh2: (Hex 0x1388) -1, LIBSSH2_ERROR_SOCKET_NONE
+No socket is available or has been provided for the SSH session.
 </nierror>
 <nierror code="5001">
 libssh2: (Hex 0x1389) -2, LIBSSH2_ERROR_BANNER_RECV
+There was an error receiving the banner from the remote host.
 </nierror>
 <nierror code="5002">
 libssh2: (Hex 0x138A) -3, LIBSSH2_ERROR_BANNER_SEND
+There was an error sending the banner to the remote host.
 </nierror>
 <nierror code="5003">
 libssh2: (Hex 0x138B) -4, LIBSSH2_ERROR_INVALID_MAC
+The message authentication code is invalid.
 </nierror>
 <nierror code="5004">
 libssh2: (Hex 0x138C) -5, LIBSSH2_ERROR_KEX_FAILURE
+The key exchange process failed.
 </nierror>
 <nierror code="5005">
 libssh2: (Hex 0x138D) -6, LIBSSH2_ERROR_ALLOC
+An internal memory allocation call failed.
 </nierror>
 <nierror code="5006">
 libssh2: (Hex 0x138E) -7, LIBSSH2_ERROR_SOCKET_SEND
+There was an error sending data on the socket.
 </nierror>
 <nierror code="5007">
 libssh2: (Hex 0x138F) -8, LIBSSH2_ERROR_KEY_EXCHANGE_FAILURE
+The key exchange process failed.
 </nierror>
 <nierror code="5008">
 libssh2: (Hex 0x1390) -9, LIBSSH2_ERROR_TIMEOUT
+The operation timed out.
 </nierror>
 <nierror code="5009">
 libssh2: (Hex 0x1391) -10, LIBSSH2_ERROR_HOSTKEY_INIT
+The host key initialization failed.
 </nierror>
 <nierror code="5010">
 libssh2: (Hex 0x1392) -11, LIBSSH2_ERROR_HOSTKEY_SIGN
+The host key signing failed.
 </nierror>
 <nierror code="5011">
 libssh2: (Hex 0x1393) -12, LIBSSH2_ERROR_DECRYPT
+The decryption process failed.
 </nierror>
 <nierror code="5012">
 libssh2: (Hex 0x1394) -13, LIBSSH2_ERROR_SOCKET_DISCONNECT
+The socket was disconnected.
 </nierror>
 <nierror code="5013">
 libssh2: (Hex 0x1395) -14, LIBSSH2_ERROR_PROTO
+An error occurred in the SSH protocol.
 </nierror>
 <nierror code="5014">
 libssh2: (Hex 0x1396) -15, LIBSSH2_ERROR_PASSWORD_EXPIRED
+The password has expired.
 </nierror>
 <nierror code="5015">
 libssh2: (Hex 0x1397) -16, LIBSSH2_ERROR_FILE
+An error occurred while working with a file.
 </nierror>
 <nierror code="5016">
 libssh2: (Hex 0x1398) -17, LIBSSH2_ERROR_METHOD_NONE
+The authentication method is not supported.
 </nierror>
 <nierror code="5017">
 libssh2: (Hex 0x1399) -18, LIBSSH2_ERROR_AUTHENTICATION_FAILED
+The authentication process failed.
 </nierror>
 <nierror code="5018">
 libssh2: (Hex 0x139A) -19, LIBSSH2_ERROR_PUBLICKEY_UNVERIFIED
+The public key is unverified.
 </nierror>
 <nierror code="5019">
 libssh2: (Hex 0x139B) -20, LIBSSH2_ERROR_CHANNEL_OUTOFORDER
+The channel is out of order.
 </nierror>
 <nierror code="5020">
 libssh2: (Hex 0x139C) -21, LIBSSH2_ERROR_CHANNEL_FAILURE
+The channel failed.
 </nierror>
 <nierror code="5021">
 libssh2: (Hex 0x139D) -22, LIBSSH2_ERROR_CHANNEL_REQUEST_DENIED
+The channel request was denied.
 </nierror>
 <nierror code="5022">
 libssh2: (Hex 0x139E) -23, LIBSSH2_ERROR_CHANNEL_UNKNOWN
+The channel is unknown.
 </nierror>
 <nierror code="5023">
 libssh2: (Hex 0x139F) -24, LIBSSH2_ERROR_CHANNEL_WINDOW_EXCEEDED
+The channel window was exceeded.
 </nierror>
 <nierror code="5024">
 libssh2: (Hex 0x13A0) -25, LIBSSH2_ERROR_CHANNEL_PACKET_EXCEEDED
+The channel packet was exceeded.
 </nierror>
 <nierror code="5025">
 libssh2: (Hex 0x13A1) -26, LIBSSH2_ERROR_CHANNEL_CLOSED
+The channel was closed.
 </nierror>
 <nierror code="5026">
 libssh2: (Hex 0x13A2) -27, LIBSSH2_ERROR_CHANNEL_EOF_SENT
+The channel end-of-file was sent.
 </nierror>
 <nierror code="5027">
 libssh2: (Hex 0x13A3) -28, LIBSSH2_ERROR_SCP_PROTOCOL
+An error occurred in the SCP protocol.
 </nierror>
 <nierror code="5028">
 libssh2: (Hex 0x13A4) -29, LIBSSH2_ERROR_ZLIB
+An error occurred in the ZLIB compression.
 </nierror>
 <nierror code="5029">
 libssh2: (Hex 0x13A5) -30, LIBSSH2_ERROR_SOCKET_TIMEOUT
+The socket timed out.
 </nierror>
 <nierror code="5030">
 libssh2: (Hex 0x13A6) -31, LIBSSH2_ERROR_SFTP_PROTOCOL
+An error occurred in the SFTP protocol.
 </nierror>
 <nierror code="5031">
 libssh2: (Hex 0x13A7) -32, LIBSSH2_ERROR_REQUEST_DENIED
+The request was denied.
 </nierror>
 <nierror code="5032">
 libssh2: (Hex 0x13A8) -33, LIBSSH2_ERROR_METHOD_NOT_SUPPORTED
+The method is not supported.
 </nierror>
 <nierror code="5033">
 libssh2: (Hex 0x13A9) -34, LIBSSH2_ERROR_INVAL
+An invalid value was provided.
 </nierror>
 <nierror code="5034">
 libssh2: (Hex 0x13AA) -35, LIBSSH2_ERROR_INVALID_POLL_TYPE
+The poll type is invalid.
 </nierror>
 <nierror code="5035">
 libssh2: (Hex 0x13AB) -36, LIBSSH2_ERROR_PUBLICKEY_PROTOCOL
+An error occurred in the public key protocol.
 </nierror>
 <nierror code="5036">
 libssh2: (Hex 0x13AC) -37, LIBSSH2_ERROR_EAGAIN
+The operation would block. Repeat the call when it would not block.
 </nierror>
 <nierror code="5037">
 libssh2: (Hex 0x13AD) -38, LIBSSH2_ERROR_BUFFER_TOO_SMALL
+The buffer is too small.
 </nierror>
 <nierror code="5038">
 libssh2: (Hex 0x13AE) -39, LIBSSH2_ERROR_BAD_USE
+The function was used incorrectly.
 </nierror>
 <nierror code="5039">
 libssh2: (Hex 0x13AF) -40, LIBSSH2_ERROR_COMPRESS
+An error occurred during compression.
 </nierror>
 <nierror code="5040">
 libssh2: (Hex 0x13B0) -41, LIBSSH2_ERROR_OUT_OF_BOUNDARY
+The package size exceeds the boundary.
 </nierror>
 <nierror code="5041">
 libssh2: (Hex 0x13B1) -42, LIBSSH2_ERROR_AGENT_PROTOCOL
+An error occurred in the agent protocol.
 </nierror>
 <nierror code="5042">
 libssh2: (Hex 0x13B2) -43, LIBSSH2_ERROR_SOCKET_RECV
+There was an error receiving data on the socket.
 </nierror>
 <nierror code="5043">
 libssh2: (Hex 0x13B3) -44, LIBSSH2_ERROR_ENCRYPT
+An error occurred during encryption.
 </nierror>
 <nierror code="5044">
 libssh2: (Hex 0x13B4) -45, LIBSSH2_ERROR_BAD_SOCKET
+The socket is invalid.
 </nierror>
 <nierror code="5045">
 libssh2: (Hex 0x13B5) -46, LIBSSH2_ERROR_KNOWN_HOSTS
+An error occurred when parsing the known hosts file.
 </nierror>
 <nierror code="5046">
 libssh2: (Hex 0x13B6) -47, LIBSSH2_ERROR_CHANNEL_WINDOW_FULL
+The channel window is full.
 </nierror>
 <nierror code="5047">
 libssh2: (Hex 0x13B7) -48, LIBSSH2_ERROR_KEYFILE_AUTH_FAILED
+The key file authentication failed.
 </nierror>
 <nierror code="5048">
 libssh2: (Hex 0x13B8) -49, LIBSSH2_ERROR_RANDGEN
+An error occurred in the random number generator.
 </nierror>
 <nierror code="5049">
 libssh2: (Hex 0x13B9) -50, LIBSSH2_ERROR_MISSING_USERAUTH_BANNER
+The user authentication banner is missing.
 </nierror>
 <nierror code="5050">
 libssh2: (Hex 0x13BA) -51, LIBSSH2_ERROR_ALGO_UNSUPPORTED
+
 </nierror>
 </nidocument>

--- a/lvssh2-sftp-errors.txt
+++ b/lvssh2-sftp-errors.txt
@@ -7,65 +7,86 @@
 </nicomment>
 <nierror code="6000">
 libssh2-sftp: (Hex 0x1770) 1, LIBSSH2_FX_EOF
+An attempt to read past the end-of-file was made; or, there are no more directory entries to return.
 </nierror>
 <nierror code="6001">
 libssh2-sftp: (Hex 0x1771) 2, LIBSSH2_FX_NO_SUCH_FILE
+The file referenced by the request does not exist.
 </nierror>
 <nierror code="6002">
 libssh2-sftp: (Hex 0x1772) 3, LIBSSH2_FX_PERMISSION_DENIED
+The user does not have sufficient permissions to perform the operation.
 </nierror>
 <nierror code="6003">
 libssh2-sftp: (Hex 0x1773) 4, LIBSSH2_FX_FAILURE
+An error occurred, but no specific error code exists to describe the failure.
 </nierror>
 <nierror code="6004">
 libssh2-sftp: (Hex 0x1774) 5, LIBSSH2_FX_BAD_MESSAGE
+A badly formatted packet or other SFTP protocol incompatibility was detected.
 </nierror>
 <nierror code="6005">
 libssh2-sftp: (Hex 0x1775) 6, LIBSSH2_FX_NO_CONNECTION
+There is no connection to the server.
 </nierror>
 <nierror code="6006">
 libssh2-sftp: (Hex 0x1776) 7, LIBSSH2_FX_CONNECTION_LOST
+The connection to the server was lost.
 </nierror>
 <nierror code="6007">
 libssh2-sftp: (Hex 0x1777) 8, LIBSSH2_FX_OP_UNSUPPORTED
+The requested operation is not supported by the server.
 </nierror>
 <nierror code="6008">
 libssh2-sftp: (Hex 0x1778) 9, LIBSSH2_FX_INVALID_HANDLE
+An invalid handle was specified.
 </nierror>
 <nierror code="6009">
 libssh2-sftp: (Hex 0x1779) 10, LIBSSH2_FX_NO_SUCH_PATH
+The file referenced by the request does not exist.
 </nierror>
 <nierror code="6010">
 libssh2-sftp: (Hex 0x177A) 11, LIBSSH2_FX_FILE_ALREADY_EXISTS
+The file already exists.
 </nierror>
 <nierror code="6011">
 libssh2-sftp: (Hex 0x177B) 12, LIBSSH2_FX_WRITE_PROTECT
+The file is on read-only media, or the media is write protected.
 </nierror>
 <nierror code="6012">
 libssh2-sftp: (Hex 0x177C) 13, LIBSSH2_FX_NO_MEDIA
+The requested operation cannot be completed because there is no media available in the drive.
 </nierror>
 <nierror code="6013">
 libssh2-sftp: (Hex 0x177D) 14, LIBSSH2_FX_NO_SPACE_ON_FILESYSTEM
+The requested operation cannot be completed because there is no space left on the filesystem.
 </nierror>
 <nierror code="6014">
 libssh2-sftp: (Hex 0x177E) 15, LIBSSH2_FX_QUOTA_EXCEEDED
+The operation cannot be completed because it would exceed the user's storage quota.
 </nierror>
 <nierror code="6015">
 libssh2-sftp: (Hex 0x177F) 16, LIBSSH2_FX_UNKNOWN_PRINCIPAL
+The operation cannot be completed because the user is not recognized by the server.
 </nierror>
 <nierror code="6016">
 libssh2-sftp: (Hex 0x1780) 17, LIBSSH2_FX_LOCK_CONFLICT
+The requested operation cannot be completed because it would cause a lock conflict.
 </nierror>
 <nierror code="6017">
 libssh2-sftp: (Hex 0x1781) 18, LIBSSH2_FX_DIR_NOT_EMPTY
+The requested operation cannot be completed because the directory is not empty.
 </nierror>
 <nierror code="6018">
 libssh2-sftp: (Hex 0x1782) 19, LIBSSH2_FX_NOT_A_DIRECTORY
+The requested operation cannot be completed because the file is not a directory.
 </nierror>
 <nierror code="6019">
 libssh2-sftp: (Hex 0x1783) 20, LIBSSH2_FX_INVALID_FILENAME
+The requested operation cannot be completed because the filename is invalid.
 </nierror>
 <nierror code="6020">
 libssh2-sftp: (Hex 0x1784) 21, LIBSSH2_FX_LINK_LOOP
+The requested operation cannot be completed because it would cause a loop in symbolic links.
 </nierror>
 </nidocument>

--- a/lvssh2-sftp-errors.txt
+++ b/lvssh2-sftp-errors.txt
@@ -6,66 +6,66 @@
 </nifamily>
 </nicomment>
 <nierror code="6000">
-libssh2-sftp: (Hex 0x1770) LIBSSH2_FX_EOF
+libssh2-sftp: (Hex 0x1770) 1, LIBSSH2_FX_EOF
 </nierror>
 <nierror code="6001">
-libssh2-sftp: (Hex 0x1771) LIBSSH2_FX_NO_SUCH_FILE
+libssh2-sftp: (Hex 0x1771) 2, LIBSSH2_FX_NO_SUCH_FILE
 </nierror>
 <nierror code="6002">
-libssh2-sftp: (Hex 0x1772) LIBSSH2_FX_PERMISSION_DENIED
+libssh2-sftp: (Hex 0x1772) 3, LIBSSH2_FX_PERMISSION_DENIED
 </nierror>
 <nierror code="6003">
-libssh2-sftp: (Hex 0x1773) LIBSSH2_FX_FAILURE
+libssh2-sftp: (Hex 0x1773) 4, LIBSSH2_FX_FAILURE
 </nierror>
 <nierror code="6004">
-libssh2-sftp: (Hex 0x1774) LIBSSH2_FX_BAD_MESSAGE
+libssh2-sftp: (Hex 0x1774) 5, LIBSSH2_FX_BAD_MESSAGE
 </nierror>
 <nierror code="6005">
-libssh2-sftp: (Hex 0x1775) LIBSSH2_FX_NO_CONNECTION
+libssh2-sftp: (Hex 0x1775) 6, LIBSSH2_FX_NO_CONNECTION
 </nierror>
 <nierror code="6006">
-libssh2-sftp: (Hex 0x1776) LIBSSH2_FX_CONNECTION_LOST
+libssh2-sftp: (Hex 0x1776) 7, LIBSSH2_FX_CONNECTION_LOST
 </nierror>
 <nierror code="6007">
-libssh2-sftp: (Hex 0x1777) LIBSSH2_FX_OP_UNSUPPORTED
+libssh2-sftp: (Hex 0x1777) 8, LIBSSH2_FX_OP_UNSUPPORTED
 </nierror>
 <nierror code="6008">
-libssh2-sftp: (Hex 0x1778) LIBSSH2_FX_INVALID_HANDLE
+libssh2-sftp: (Hex 0x1778) 9, LIBSSH2_FX_INVALID_HANDLE
 </nierror>
 <nierror code="6009">
-libssh2-sftp: (Hex 0x1779) LIBSSH2_FX_NO_SUCH_PATH
+libssh2-sftp: (Hex 0x1779) 10, LIBSSH2_FX_NO_SUCH_PATH
 </nierror>
 <nierror code="6010">
-libssh2-sftp: (Hex 0x177A) LIBSSH2_FX_FILE_ALREADY_EXISTS
+libssh2-sftp: (Hex 0x177A) 11, LIBSSH2_FX_FILE_ALREADY_EXISTS
 </nierror>
 <nierror code="6011">
-libssh2-sftp: (Hex 0x177B) LIBSSH2_FX_WRITE_PROTECT
+libssh2-sftp: (Hex 0x177B) 12, LIBSSH2_FX_WRITE_PROTECT
 </nierror>
 <nierror code="6012">
-libssh2-sftp: (Hex 0x177C) LIBSSH2_FX_NO_MEDIA
+libssh2-sftp: (Hex 0x177C) 13, LIBSSH2_FX_NO_MEDIA
 </nierror>
 <nierror code="6013">
-libssh2-sftp: (Hex 0x177D) LIBSSH2_FX_NO_SPACE_ON_FILESYSTEM
+libssh2-sftp: (Hex 0x177D) 14, LIBSSH2_FX_NO_SPACE_ON_FILESYSTEM
 </nierror>
 <nierror code="6014">
-libssh2-sftp: (Hex 0x177E) LIBSSH2_FX_QUOTA_EXCEEDED
+libssh2-sftp: (Hex 0x177E) 15, LIBSSH2_FX_QUOTA_EXCEEDED
 </nierror>
 <nierror code="6015">
-libssh2-sftp: (Hex 0x177F) LIBSSH2_FX_UNKNOWN_PRINCIPAL
+libssh2-sftp: (Hex 0x177F) 16, LIBSSH2_FX_UNKNOWN_PRINCIPAL
 </nierror>
 <nierror code="6016">
-libssh2-sftp: (Hex 0x1780) LIBSSH2_FX_LOCK_CONFLICT
+libssh2-sftp: (Hex 0x1780) 17, LIBSSH2_FX_LOCK_CONFLICT
 </nierror>
 <nierror code="6017">
-libssh2-sftp: (Hex 0x1781) LIBSSH2_FX_DIR_NOT_EMPTY
+libssh2-sftp: (Hex 0x1781) 18, LIBSSH2_FX_DIR_NOT_EMPTY
 </nierror>
 <nierror code="6018">
-libssh2-sftp: (Hex 0x1782) LIBSSH2_FX_NOT_A_DIRECTORY
+libssh2-sftp: (Hex 0x1782) 19, LIBSSH2_FX_NOT_A_DIRECTORY
 </nierror>
 <nierror code="6019">
-libssh2-sftp: (Hex 0x1783) LIBSSH2_FX_INVALID_FILENAME
+libssh2-sftp: (Hex 0x1783) 20, LIBSSH2_FX_INVALID_FILENAME
 </nierror>
 <nierror code="6020">
-libssh2-sftp: (Hex 0x1784) LIBSSH2_FX_LINK_LOOP
+libssh2-sftp: (Hex 0x1784) 21, LIBSSH2_FX_LINK_LOOP
 </nierror>
 </nidocument>


### PR DESCRIPTION
This PR adds the original error codes from libssh2 and additional error descriptions to the custom error definitions. Since libssh2 does not provide more details on their error codes, these descriptions were derived from how errors are used by libssh2.