### PR TITLE
Allow using official libssh2 source tarballs and signatures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,25 @@ set(CMAKE_C_STANDARD_REQUIRED YES)
 set(CMAKE_C_EXTENSIONS OFF)
 
 set(
+  LIBSSH2_SOURCE "GitHub"
+  CACHE STRING "Source of the libssh2 library."
+)
+set_property(CACHE LIBSSH2_SOURCE PROPERTY STRINGS "GitHub" "Tarball")
+
+set(
   LIBSSH2_COMMIT_HASH "a312b43325e3383c865a87bb1d26cb52e3292641"
-  CACHE STRING "Commit hash of the libssh2 repository. Also accepts branch names and tags. The use of commit hashes is strongly recommended to avoid pulling malicious code."
+  CACHE STRING "Commit hash of the libssh2 repository. Also accepts branch names and tags. The use of commit hashes is strongly recommended to avoid pulling malicious code. Only used when LIBSSH2_SOURCE is GitHub."
 )
 
-message(STATUS "LIBSSH2_COMMIT_HASH: ${LIBSSH2_COMMIT_HASH}")
+set(
+  LIBSSH2_URL "https://libssh2.org/download/libssh2-1.11.1.tar.gz"
+  CACHE STRING "URL of the libssh2 tarball. Only used when LIBSSH2_SOURCE is Tarball."
+)
+
+set(
+  LIBSSH2_URL_SIG "https://libssh2.org/download/libssh2-1.11.1.tar.gz.asc"
+  CACHE STRING "URL of the libssh2 tarball PGP signature. Only used when LIBSSH2_SOURCE is Tarball."
+)
 
 # Set output directory to libssh2
 # $<1:...> is used to prevent Visual Studio from appending a configuration name to the output directory
@@ -27,14 +41,45 @@ endif()
 # Get libssh2 source code
 include(FetchContent)
 
-FetchContent_Declare(
-  libssh2
-  GIT_REPOSITORY https://github.com/libssh2/libssh2.git
-  GIT_TAG ${LIBSSH2_COMMIT_HASH}
-  SOURCE_SUBDIR include
-)
+if(${LIBSSH2_SOURCE} STREQUAL "GitHub")
+  FetchContent_Declare(
+    libssh2
+    GIT_REPOSITORY https://github.com/libssh2/libssh2.git
+    GIT_TAG ${LIBSSH2_COMMIT_HASH}
+    SOURCE_SUBDIR include
+  )
+elseif(${LIBSSH2_SOURCE} STREQUAL "Tarball")
+  # Download the tarball and its PGP signature
+  file(DOWNLOAD ${LIBSSH2_URL} ${CMAKE_BINARY_DIR}/libssh2.tar.gz)
+  file(DOWNLOAD ${LIBSSH2_URL_SIG} ${CMAKE_BINARY_DIR}/libssh2.tar.gz.sig)
+
+  # Verify the PGP signature
+  execute_process(
+    COMMAND gpg --verify ${CMAKE_BINARY_DIR}/libssh2.tar.gz.sig ${CMAKE_BINARY_DIR}/libssh2.tar.gz
+    RESULT_VARIABLE GPG_RESULT
+    OUTPUT_VARIABLE GPG_OUTPUT
+    ERROR_VARIABLE GPG_ERROR
+  )
+
+  if(NOT GPG_RESULT EQUAL 0)
+    message(FATAL_ERROR "PGP signature verification failed: ${GPG_ERROR}")
+  else()
+    message(STATUS "PGP signature verification succeeded.")
+  endif()
+
+  # Use the verified tarball
+  FetchContent_Declare(
+    libssh2
+    URL file://${CMAKE_BINARY_DIR}/libssh2.tar.gz
+    SOURCE_SUBDIR include
+    DOWNLOAD_EXTRACT_TIMESTAMP ON
+  )
+else()
+  message(FATAL_ERROR "Invalid value for LIBSSH2_SOURCE: ${LIBSSH2_SOURCE}")
+endif()
 
 FetchContent_MakeAvailable(libssh2)
+FetchContent_GetProperties(libssh2)
 
 # Set LabVIEW base path based on the platform
 if(CMAKE_HOST_WIN32)
@@ -82,8 +127,7 @@ include(ExternalProject)
 
 ExternalProject_Add(
   libssh2
-  GIT_REPOSITORY https://github.com/libssh2/libssh2.git
-  GIT_TAG ${LIBSSH2_COMMIT_HASH}
+  SOURCE_DIR ${libssh2_SOURCE_DIR}
   CMAKE_ARGS
     -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=$<1:${CMAKE_BINARY_DIR}>
     -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG=$<1:${CMAKE_BINARY_DIR}>

--- a/docs/cmake-build-instructions.md
+++ b/docs/cmake-build-instructions.md
@@ -61,4 +61,7 @@ These options provide additional customization of the build process. They can be
 
 | Option | Description |
 | ------ | ----------- |
-| `LIBSSH2_COMMIT_HASH` | Commit hash of the libssh2 repository. Also accepts branch names and tags. The use of commit hashes is **strongly recommended** to avoid pulling malicious code. |
+| `LIBSSH2_SOURCE` | Source of the libssh2 library. Available options are: "GitHub" and "Tarball". Default is "GitHub". |
+| `LIBSSH2_COMMIT_HASH` | Requires `LIBSSH2_SOURCE=GitHub`.<br><br> Commit hash of the libssh2 repository. Also accepts branch names and tags. The use of commit hashes is **strongly recommended** to avoid pulling malicious code. |
+| `LIBSSH2_URL` | Requires `LIBSSH2_SOURCE=Tarball`.<br><br> URL of the libssh2 tarball. See https://libssh2.org/ |
+| `LIBSSH2_URL_SIG` | Requires `LIBSSH2_SOURCE=Tarball`.<br><br> URL of the libssh2 tarball signature. The public key used to verify the signature must be available on the system prior to building. |


### PR DESCRIPTION
This enables the use of official libssh2 source tarballs and signatures by introducing additional options to the CMake build script:

- LIBSSH2_SOURCE : Specifies the source of the libssh2 library (GitHub or Tarball)
- LIBSSH2_URL : Specifies the URL of the libssh2 tarball
- LIBSSH2_URL_SIG : Specifies the URL of the libssh2 tarball signature

During the build process, the tarball is downloaded and verified. The public key used to verify the signature must be available on the system prior to building.