### PR TITLE
azure-pipelines: Publish OpenSSH server logs after test completion

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,12 @@ steps:
   inputs:
     script: 'LabVIEWCLI -LabVIEWPath "%LabVIEW%\LabVIEW.exe" -AdditionalOperationDirectory "$(Build.SourcesDirectory)\Toolchain" -OperationName Test -Project "$(Build.SourcesDirectory)\lvssh2.lvproj" -ResultsFolder "$(System.DefaultWorkingDirectory)\TestResults"'
     workingDirectory: '$(Build.SourcesDirectory)'
+- script: docker compose down
+  displayName: 'Stop SSH server'
+  workingDirectory: '$(Build.SourcesDirectory)/docker'
+- publish: '$(System.DefaultWorkingDirectory)/docker/openssh-server/config/logs/openssh/current'
+  displayName: 'Publish SSH server logs'
+  artifact: SSH server logs
 - task: PublishTestResults@2
   displayName: 'Publish test results'
   inputs:


### PR DESCRIPTION
This will allow for better analysis should a failure occur on the server side. Currently, this must be done offline, which does not always work as some issues are only reproducible on the build servers.