### PR TITLE
azure-pipelines: Use strategy to configure build configurations

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,12 @@
 trigger:
-- '*'
+  branches:
+    include:
+    - main
+
+pr:
+  branches:
+    include:
+    - main
 
 pool:
   name: Default

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,13 +5,22 @@ pool:
   name: Default
   demands: LabVIEW
 
+variables:
+  libssh2.version: '1.11.1'
+  libssh2.commit: 'a312b43325e3383c865a87bb1d26cb52e3292641'
+
 strategy:
   matrix:
-    'libssh2-1.11.1-x86':
+    'libssh2-1.11.1-x86-debug':
       architecture: 'Win32'
       source: 'GitHub'
-      commit: 'a312b43325e3383c865a87bb1d26cb52e3292641'
+      commit: $(libssh2.commit)
       config: 'Debug'
+    'libssh2-1.11.1-x86-release':
+      architecture: 'Win32'
+      source: 'GitHub'
+      commit: $(libssh2.commit)
+      config: 'Release'
 
 steps:
 - task: CmdLine@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,7 +51,7 @@ steps:
   workingDirectory: '$(Build.SourcesDirectory)/docker'
 - publish: '$(System.DefaultWorkingDirectory)/docker/openssh-server/config/logs/openssh/current'
   displayName: 'Publish SSH server logs'
-  artifact: SSH server logs
+  artifact: server-log-($(Agent.JobName))
 - task: PublishTestResults@2
   displayName: 'Publish test results'
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,21 +5,24 @@ pool:
   name: Default
   demands: LabVIEW
 
-variables:
-  libssh2.CommitHash: 'a312b43325e3383c865a87bb1d26cb52e3292641' # libssh2-1.11.1
+strategy:
+  matrix:
+    'libssh2-1.11.1-x86':
+      architecture: 'Win32'
+      source: 'GitHub'
+      commit: 'a312b43325e3383c865a87bb1d26cb52e3292641'
+      config: 'Debug'
 
 steps:
 - task: CmdLine@2
   displayName: 'Prepare build configurations'
   inputs:
-    script: cmake -B build/x32 -S . -G "Visual Studio 17 2022" -A Win32 -DLIBSSH2_COMMIT_HASH=$(libssh2.CommitHash)
-            && cmake -B build/x64 -S . -G "Visual Studio 17 2022" -A x64 -DLIBSSH2_COMMIT_HASH=$(libssh2.CommitHash)
+    script: cmake -B build/$(architecture) -S . -G "Visual Studio 17 2022" -A $(architecture) -DLIBSSH2_SOURCE=$(source) -DLIBSSH2_COMMIT_HASH=$(commit)
     workingDirectory: '$(Build.SourcesDirectory)'
 - task: CmdLine@2
   displayName: 'Build libraries'
   inputs:
-    script: cmake --build build/x32 --config Debug
-            && cmake --build build/x64 --config Debug
+    script: cmake --build build/$(architecture) --config $(config)
     workingDirectory: '$(Build.SourcesDirectory)'
 - script: docker compose up -d --force-recreate
   displayName: 'Start SSH server'


### PR DESCRIPTION
The build pipeline currently makes no assumption on the build agent and simply builds for both x86 and x64 targets. It is then up to the agent to use whatever it can handle. The problem with this approach is that it is not clear to the viewer that only the x86 or x64 target has been tested (in fact, only the x86 target is tested).

This changes the pipeline to specify the target and configuration explicitly.