### PR TITLE
Bump OpenSSL from 3.4.0 to 3.4.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,8 +15,8 @@ pool:
 variables:
   libssh2.version: '1.11.1'
   libssh2.commit: 'a312b43325e3383c865a87bb1d26cb52e3292641'
-  openssl.version: '3.4.0'
-  openssl.commit: '98acb6b02839c609ef5b837794e08d906d965335'
+  openssl.version: '3.4.1'
+  openssl.commit: 'a26d85337dbdcd33c971f38eb3fa5150e75cea87'
 
 strategy:
   matrix:

--- a/build.sh
+++ b/build.sh
@@ -32,13 +32,13 @@ for arch in "${build_archs[@]}"; do
     else
         cmake_cmd+=" -DCMAKE_BUILD_TYPE=Debug"
         cmake_cmd+=" -DLIBSSH2_SOURCE=GitHub"
-        cmake_cmd+=" -DLIBSSH2_COMMIT_HASH=libssh2-1.11.1"
+        cmake_cmd+=" -DLIBSSH2_COMMIT_HASH=a312b43325e3383c865a87bb1d26cb52e3292641"
     fi
 
     cmake_cmd+=" -DCRYPTO_BACKEND=$crypto_backend"
 
     if [[ "$crypto_backend" == "OpenSSL" ]]; then
-        cmake_cmd+=" -DOPENSSL_COMMIT_HASH=openssl-3.4.0"
+        cmake_cmd+=" -DOPENSSL_COMMIT_HASH=a26d85337dbdcd33c971f38eb3fa5150e75cea87"
     fi
 
     eval $cmake_cmd


### PR DESCRIPTION
This updates OpenSSL to https://github.com/openssl/openssl/releases/tag/openssl-3.4.1