### PR TITLE
Publish code coverage results

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,3 +65,8 @@ steps:
     testResultsFormat: 'JUnit'
     testResultsFiles: '**/TEST-*.xml'
     failTaskOnFailedTests: true
+- task: PublishCodeCoverageResults@2
+  inputs:
+    summaryFileLocation: '**/COVERAGE-*.xml'
+    pathToSources: '$(System.DefaultWorkingDirectory)/src'
+    failIfCoverageEmpty: true


### PR DESCRIPTION
This adds a build task to publish code coverage results to the pipeline.
Note that code coverage is reported as "number of lines", which does not
work well with LabVIEW but gives some indicator as to how much code is 
covered.

Code coverage does not include any of the non-LabVIEW source files.