### PR TITLE
Optimize CI Pipeline

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,22 +266,12 @@ else()
   )
 endif()
 
-# Custom command to rename the DLL
-add_custom_command(
-  TARGET libssh2
-  POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E rename
-    ${CMAKE_BINARY_DIR}/libssh2${CMAKE_SHARED_LIBRARY_SUFFIX}
-    ${CMAKE_BINARY_DIR}/libssh2${OUTPUT_NAME_SUFFIX}${CMAKE_SHARED_LIBRARY_SUFFIX}
-  COMMENT "Renaming libssh2${CMAKE_SHARED_LIBRARY_SUFFIX} to libssh2${OUTPUT_NAME_SUFFIX}${CMAKE_SHARED_LIBRARY_SUFFIX}"
-)
-
 # Custom command to move the DLL to the libssh2 directory
 add_custom_command(
   TARGET libssh2
   POST_BUILD
   COMMAND ${CMAKE_COMMAND} -E copy
-    ${CMAKE_BINARY_DIR}/libssh2${OUTPUT_NAME_SUFFIX}${CMAKE_SHARED_LIBRARY_SUFFIX}
-    ${CMAKE_SOURCE_DIR}/libssh2
+    ${CMAKE_BINARY_DIR}/libssh2${CMAKE_SHARED_LIBRARY_SUFFIX}
+    ${CMAKE_SOURCE_DIR}/libssh2/libssh2${OUTPUT_NAME_SUFFIX}${CMAKE_SHARED_LIBRARY_SUFFIX}
   COMMENT "Copying libssh2${OUTPUT_NAME_SUFFIX}${CMAKE_SHARED_LIBRARY_SUFFIX} to libssh2 directory"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,9 @@ if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows" AND CRYPTO_BACKEND STREQUAL "OpenSS
       ${OPENSSL_CONFIGURE_COMMAND}
       --prefix=${OPENSSL_INSTALL_DIR}
       --openssldir=${OPENSSL_INSTALL_DIR}
+      no-apps
+      no-docs
+      no-tests
     BUILD_COMMAND nmake
     BUILD_IN_SOURCE 1
     INSTALL_COMMAND nmake install

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,11 @@ pr:
   branches:
     include:
     - main
+    exclude:
+    - docs/*
+    - images/*
+    - '*.md'
+    - '*.txt'
 
 pool:
   name: Default

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,7 @@ variables:
   libssh2.commit: 'a312b43325e3383c865a87bb1d26cb52e3292641'
   openssl.version: '3.5.2'
   openssl.commit: '0893a62353583343eb712adef6debdfbe597c227'
+  DLL_CACHE_FOLDER: '$(System.DefaultWorkingDirectory)/Cache'
 
 strategy:
   matrix:
@@ -35,13 +36,33 @@ strategy:
       config: 'Release'
 
 steps:
+- task: Cache@2
+  displayName: 'Cache built DLLs'
+  inputs:
+    key: '"dlls" | "$(architecture)" | "$(backend)" | "$(config)" | "$(libssh2.commit)" | "$(openssl.commit)"'
+    path: '$(DLL_CACHE_FOLDER)'
+    cacheHitVar: CACHE_RESTORED
+- task: CmdLine@2
+  displayName: 'Restore cache files'
+  condition: eq(variables.CACHE_RESTORED, 'true')
+  inputs:
+    script: |
+      if not exist "$(DLL_CACHE_FOLDER)\*.dll" (
+        echo "No cached DLLs found."
+      ) else (
+        echo "Restoring cached DLLs..."
+        xcopy "$(DLL_CACHE_FOLDER)\*.dll" "$(Build.SourcesDirectory)\libssh2\" /Y /I
+      )
+    workingDirectory: '$(Build.SourcesDirectory)'
 - task: CmdLine@2
   displayName: 'Prepare build configurations'
+  condition: ne(variables.CACHE_RESTORED, 'true')
   inputs:
     script: cmake -B build/$(architecture) -S . -G "Visual Studio 17 2022" -A $(architecture) -DLIBSSH2_SOURCE=GitHub -DLIBSSH2_COMMIT_HASH=$(libssh2.commit) -DCRYPTO_BACKEND=$(backend) -DOPENSSL_COMMIT_HASH=$(openssl.commit)
     workingDirectory: '$(Build.SourcesDirectory)'
 - task: CmdLine@2
   displayName: 'Build libraries'
+  condition: ne(variables.CACHE_RESTORED, 'true')
   inputs:
     script: cmake --build build/$(architecture) --config $(config)
     workingDirectory: '$(Build.SourcesDirectory)'
@@ -75,3 +96,11 @@ steps:
     summaryFileLocation: '**/COVERAGE-*.xml'
     pathToSources: '$(System.DefaultWorkingDirectory)/src'
     failIfCoverageEmpty: true
+- task: CmdLine@2
+  displayName: 'Prepare cache files'
+  inputs:
+    script: |
+      if not exist "$(DLL_CACHE_FOLDER)" (
+        mkdir "$(DLL_CACHE_FOLDER)"
+      )
+      xcopy "$(Build.SourcesDirectory)\libssh2\*.dll" "$(DLL_CACHE_FOLDER)\" /Y /I


### PR DESCRIPTION
This introduces several changes to the CI pipeline to skip running builds for meta files and cache binary files for libssh2 and OpenSSL so that the build time of subsequent builds are much faster.