### PR TITLE
Fix unsupported OS: Cygwin

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@
 build_type=${1:-Release}
 crypto_backend=${2:-OpenSSL}
 
-if [[ "$OSTYPE" == "msys"* ]]; then
+if [[ "$OSTYPE" == "msys"* || "$OSTYPE" == "cygwin"* ]]; then
     generator="Visual Studio 17 2022"
     build_archs=("Win32" "x64")
 elif [[ "$OSTYPE" == "linux-gnu"* ]]; then


### PR DESCRIPTION
It appears that a recent update for Git for Windows causes $OSTYPE to be
reported as "cygwin" instead of "msys". In our case it does not make a
difference, which is why they are both allowed for Windows builds.