### PR TITLE
Bump OpenSSL from 4.0.0 to 4.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ set(
 set_property(CACHE CRYPTO_BACKEND PROPERTY STRINGS "OpenSSL" "WinCNG")
 
 set(
-  OPENSSL_COMMIT_HASH "11b7b6ea3b65a584e1d31408ed1bdb139465cffd"
+  OPENSSL_COMMIT_HASH "1e963a8680ec78ad2072792c7a1a71f3c530bd2e"
   CACHE STRING "Commit hash of the openssl repository. Also accepts branch names and tags. The use of commit hashes is strongly recommended to avoid pulling malicious code. Only used when CRYPTO_BACKEND is OpenSSL."
 )
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,8 +20,8 @@ pool:
 variables:
   libssh2.version: '1.11.1'
   libssh2.commit: 'a312b43325e3383c865a87bb1d26cb52e3292641'
-  openssl.version: '4.0.0'
-  openssl.commit: '11b7b6ea3b65a584e1d31408ed1bdb139465cffd'
+  openssl.version: '4.0.1'
+  openssl.commit: '1e963a8680ec78ad2072792c7a1a71f3c530bd2e'
   DLL_CACHE_FOLDER: '$(System.DefaultWorkingDirectory)/Cache'
 
 jobs:

--- a/build.sh
+++ b/build.sh
@@ -38,7 +38,7 @@ for arch in "${build_archs[@]}"; do
     cmake_cmd+=" -DCRYPTO_BACKEND=$crypto_backend"
 
     if [[ "$crypto_backend" == "OpenSSL" ]]; then
-        cmake_cmd+=" -DOPENSSL_COMMIT_HASH=11b7b6ea3b65a584e1d31408ed1bdb139465cffd"
+        cmake_cmd+=" -DOPENSSL_COMMIT_HASH=1e963a8680ec78ad2072792c7a1a71f3c530bd2e"
     fi
 
     eval $cmake_cmd


### PR DESCRIPTION
https://github.com/openssl/openssl/releases/tag/openssl-4.0.1