### PR TITLE
Add LVSSH2_ENABLE_UNSAFESEH_WIN32 build flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,12 @@ set(
   CACHE STRING "Commit hash of the openssl repository. Also accepts branch names and tags. The use of commit hashes is strongly recommended to avoid pulling malicious code. Only used when CRYPTO_BACKEND is OpenSSL."
 )
 
+option(
+  LVSSH2_ENABLE_UNSAFESEH_WIN32
+  "Allow /SAFESEH:NO on Win32 builds for compatibility with toolchains that cannot link with /SAFESEH."
+  OFF
+)
+
 # Set output directory to libssh2
 # $<1:...> is used to prevent Visual Studio from appending a configuration name to the output directory
 #          see: https://discourse.cmake.org/t/changing-output-directories/8829/2
@@ -124,8 +130,12 @@ if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows")
   if(CMAKE_SIZEOF_VOID_P EQUAL 8)
     set(LABVIEW_BASE_PATH "C:/Program Files/National Instruments")
   else()
-    # SAFESH:NO is required to prevent linker errors when building with Visual Studio
-    add_link_options(/SAFESEH:NO)
+    if(LVSSH2_ENABLE_UNSAFESEH_WIN32)
+      message(WARNING "Building with /SAFESEH:NO. This reduces Win32 exploit mitigations and should only be used when required for compatibility.")
+      add_link_options(/SAFESEH:NO)
+    else()
+      add_link_options(/SAFESEH)
+    endif()
     set(LABVIEW_BASE_PATH "C:/Program Files (x86)/National Instruments")
   endif()
 elseif(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,7 +60,7 @@ jobs:
       displayName: 'Prepare build configurations'
       condition: ne(variables.CACHE_RESTORED, 'true')
       inputs:
-        script: cmake -B build/$(architecture) -S . -G "Visual Studio 17 2022" -A $(architecture) -DLIBSSH2_SOURCE=GitHub -DLIBSSH2_COMMIT_HASH=$(libssh2.commit) -DCRYPTO_BACKEND=$(backend) -DOPENSSL_COMMIT_HASH=$(openssl.commit)
+        script: cmake -B build/$(architecture) -S . -G "Visual Studio 17 2022" -A $(architecture) -DLIBSSH2_SOURCE=GitHub -DLIBSSH2_COMMIT_HASH=$(libssh2.commit) -DCRYPTO_BACKEND=$(backend) -DOPENSSL_COMMIT_HASH=$(openssl.commit) -DLVSSH2_ENABLE_UNSAFESEH_WIN32=ON
         workingDirectory: '$(Build.SourcesDirectory)'
     - task: CmdLine@2
       displayName: 'Build libraries'

--- a/build.sh
+++ b/build.sh
@@ -23,6 +23,11 @@ for arch in "${build_archs[@]}"; do
 
     if [[ "$generator" == "Visual Studio 17 2022" ]]; then
         cmake_cmd+=" -A \"$arch\""
+
+        if [[ "$arch" == "Win32" ]]; then
+            # SAFESH:NO is required to prevent linker errors when building with Visual Studio
+            cmake_cmd+=" -DLVSSH2_ENABLE_UNSAFESEH_WIN32=ON"
+        fi
     fi
 
     if [[ "$build_type" == "Release" ]]; then

--- a/docs/cmake-build-instructions.md
+++ b/docs/cmake-build-instructions.md
@@ -71,3 +71,4 @@ These options provide additional customization of the build process. They can be
 | `LIBSSH2_URL_SIG` | Requires `LIBSSH2_SOURCE=Tarball`.<br><br> URL of the libssh2 tarball signature. The public key used to verify the signature must be available on the system prior to building. |
 | `CRYPTO_BACKEND` | Crypto backend to use. Available options are: "OpenSSL" and "WinCNG". Default is "OpenSSL". |
 | `OPENSSL_COMMIT_HASH` | Requires `CRYPTO_BACKEND=OpenSSL`.<br><br> Commit hash of the OpenSSL repository. Also accepts branch names and tags. The use of commit hashes is **strongly recommended** to avoid pulling malicious code. |
+| `LVSSH2_ENABLE_UNSAFESEH_WIN32` | Win32-only compatibility toggle for `/SAFESEH:NO`. Default is `OFF` (secure default using `/SAFESEH`). Enable only when your toolchain cannot link with `/SAFESEH`. |


### PR DESCRIPTION
This is an explicit build flag for `/SAFESEH:NO` required for Win32 builds in Visual Studio. It is exposed as an explicit build flag so that users can know that it is applied by default.