### PR TITLE
Force cache miss when relevant files change

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
     - task: Cache@2
       displayName: 'Cache built DLLs'
       inputs:
-        key: '"dlls" | "$(architecture)" | "$(backend)" | "$(config)" | "$(libssh2.commit)" | "$(openssl.commit)"'
+        key: '"dlls" | "$(architecture)" | "$(backend)" | "$(config)" | "$(libssh2.commit)" | "$(openssl.commit)" | CMakeLists.txt | extensions/**/*.*'
         path: '$(DLL_CACHE_FOLDER)'
         cacheHitVar: CACHE_RESTORED
     - task: CmdLine@2

--- a/tests/example_tests/test_examples.json
+++ b/tests/example_tests/test_examples.json
@@ -248,48 +248,6 @@
         }
     },
     {
-        "name": "ssh2",
-        "data": {
-            "file": "ssh2.vi",
-            "controls": [
-                {
-                    "label": "address",
-                    "value": "localhost"
-                },
-                {
-                    "label": "username",
-                    "value": "openssh"
-                },
-                {
-                    "label": "password",
-                    "value": "openssh"
-                },
-                {
-                    "label": "command",
-                    "value": "echo test"
-                }
-            ],
-            "expectations": [
-                {
-                    "label": "error out",
-                    "value": {
-                        "status": false,
-                        "code": 0,
-                        "source": ""
-                    }
-                },
-                {
-                    "label": "response",
-                    "value": "test\n"
-                },
-                {
-                    "label": "exit status",
-                    "value": 0
-                }
-            ]
-        }
-    },
-    {
         "name": "ssh2_echo",
         "data": {
             "file": "ssh2_echo.vi",


### PR DESCRIPTION
The cache currently does not miss when relevant build files change. This includes, CMakeLists.txt and the extensions diretory.