### PR TITLE
Enable debug trace on debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,12 @@ option(
   OFF
 )
 
+option(
+  LIBSSH2_ENABLE_DEBUG_LOGGING
+  "Build libssh2 with debug trace logging (libssh2_trace)."
+  OFF
+)
+
 # Set output directory to libssh2
 # $<1:...> is used to prevent Visual Studio from appending a configuration name to the output directory
 #          see: https://discourse.cmake.org/t/changing-output-directories/8829/2
@@ -191,6 +197,10 @@ elseif(CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
   target_link_options(${PROJECT_NAME} PRIVATE "LINKER:--allow-shlib-undefined")
 endif()
 
+if(LIBSSH2_ENABLE_DEBUG_LOGGING)
+  set(LIBSSH2_EXTRA_CMAKE_ARGS -DENABLE_DEBUG_LOGGING=ON)
+endif()
+
 set_target_properties(${PROJECT_NAME} PROPERTIES
   OUTPUT_NAME "${PROJECT_NAME}${OUTPUT_NAME_SUFFIX}"
 )
@@ -313,6 +323,7 @@ if(CMAKE_HOST_SYSTEM_NAME STREQUAL "Windows" AND CRYPTO_BACKEND STREQUAL "OpenSS
       -DOPENSSL_CRYPTO_LIBRARY=${OPENSSL_INSTALL_DIR}/lib/libcrypto.lib
       -DOPENSSL_SSL_LIBRARY=${OPENSSL_INSTALL_DIR}/lib/libssl.lib
       -DDLL_LIBCRYPTO=${CMAKE_SOURCE_DIR}/libssh2/${OPENSSL_LIBCRYPTO_FILE} # Do not rely on libssh2 discovery
+      ${LIBSSH2_EXTRA_CMAKE_ARGS}
     INSTALL_COMMAND ""
   )
 else()
@@ -328,6 +339,7 @@ else()
       -DBUILD_TESTING=OFF
       -DLIBSSH2_NO_DEPRECATED=ON
       -DCRYPTO_BACKEND=${CRYPTO_BACKEND}
+      ${LIBSSH2_EXTRA_CMAKE_ARGS}
     INSTALL_COMMAND ""
   )
 endif()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,18 +39,21 @@ jobs:
           labview_port: '%LabVIEW_64_PORT%'
           backend: 'OpenSSL'
           config: 'Debug'
+          debugLogging: 'ON'
         'x64-win-openssl-release':
           architecture: 'x64'
           labview: '%LabVIEW_64%'
           labview_port: '%LabVIEW_64_PORT%'
           backend: 'OpenSSL'
           config: 'Release'
+          debugLogging: 'OFF'
         'x86-win-openssl-release':
           architecture: 'Win32'
           labview: '%LabVIEW_32%'
           labview_port: '%LabVIEW_32_PORT%'
           backend: 'OpenSSL'
           config: 'Release'
+          debugLogging: 'OFF'
     steps:
     - task: Cache@2
       displayName: 'Cache built DLLs'
@@ -74,7 +77,7 @@ jobs:
       displayName: 'Prepare build configurations'
       condition: ne(variables.CACHE_RESTORED, 'true')
       inputs:
-        script: cmake -B build/$(architecture) -S . -G "Visual Studio 18 2026" -A $(architecture) -DLIBSSH2_SOURCE=GitHub -DLIBSSH2_COMMIT_HASH=$(libssh2.commit) -DCRYPTO_BACKEND=$(backend) -DOPENSSL_COMMIT_HASH=$(openssl.commit) -DLVSSH2_ENABLE_UNSAFESEH_WIN32=ON
+        script: cmake -B build/$(architecture) -S . -G "Visual Studio 18 2026" -A $(architecture) -DLIBSSH2_SOURCE=GitHub -DLIBSSH2_COMMIT_HASH=$(libssh2.commit) -DCRYPTO_BACKEND=$(backend) -DOPENSSL_COMMIT_HASH=$(openssl.commit) -DLVSSH2_ENABLE_UNSAFESEH_WIN32=ON -DLIBSSH2_ENABLE_DEBUG_LOGGING=$(debugLogging)
         workingDirectory: '$(Build.SourcesDirectory)'
     - task: CmdLine@2
       displayName: 'Build libraries'

--- a/build.sh
+++ b/build.sh
@@ -38,6 +38,7 @@ for arch in "${build_archs[@]}"; do
         cmake_cmd+=" -DCMAKE_BUILD_TYPE=Debug"
         cmake_cmd+=" -DLIBSSH2_SOURCE=GitHub"
         cmake_cmd+=" -DLIBSSH2_COMMIT_HASH=a312b43325e3383c865a87bb1d26cb52e3292641"
+        cmake_cmd+=" -DLIBSSH2_ENABLE_DEBUG_LOGGING=ON"
     fi
 
     cmake_cmd+=" -DCRYPTO_BACKEND=$crypto_backend"

--- a/docs/cmake-build-instructions.md
+++ b/docs/cmake-build-instructions.md
@@ -72,3 +72,4 @@ These options provide additional customization of the build process. They can be
 | `CRYPTO_BACKEND` | Crypto backend to use. Available options are: "OpenSSL" and "WinCNG". Default is "OpenSSL". |
 | `OPENSSL_COMMIT_HASH` | Requires `CRYPTO_BACKEND=OpenSSL`.<br><br> Commit hash of the OpenSSL repository. Also accepts branch names and tags. The use of commit hashes is **strongly recommended** to avoid pulling malicious code. |
 | `LVSSH2_ENABLE_UNSAFESEH_WIN32` | Win32-only compatibility toggle for `/SAFESEH:NO`. Default is `OFF` (secure default using `/SAFESEH`). Enable only when your toolchain cannot link with `/SAFESEH`. |
+| `LIBSSH2_ENABLE_DEBUG_LOGGING` | Build libssh2 with debug trace logging (libssh2_trace). Default is `OFF`. |


### PR DESCRIPTION
This adds a new build option `LIBSSH2_ENABLE_DEBUG_LOGGING`, to include debug trace in libssh2 builds. It is OFF in release builds and ON in debug builds, when using `build.sh` and in Azure Pipelines.

When building through CMake directly, the build option is OFF by default.